### PR TITLE
Potential fix for code scanning alert no. 37: Disabling certificate validation

### DIFF
--- a/src/firecrawl/apps/api/src/lib/robots-txt.ts
+++ b/src/firecrawl/apps/api/src/lib/robots-txt.ts
@@ -1,7 +1,6 @@
 import robotsParser, { Robot } from "robots-parser";
 import axios from "axios";
 import { axiosTimeout } from "./timeout";
-import https from "https";
 import { Logger } from "winston";
 
 export interface RobotsTxtChecker {
@@ -18,17 +17,9 @@ export async function fetchRobotsTxt(
   const urlObj = new URL(url);
   const robotsTxtUrl = `${urlObj.protocol}//${urlObj.host}/robots.txt`;
 
-  let extraArgs: any = {};
-  if (skipTlsVerification) {
-    extraArgs.httpsAgent = new https.Agent({
-      rejectUnauthorized: false,
-    });
-  }
-
   const response = await axios.get(robotsTxtUrl, {
     timeout: axiosTimeout,
     signal: abort,
-    ...extraArgs,
   });
 
   const contentType = (Object.entries(response.headers).find(


### PR DESCRIPTION
Potential fix for [https://github.com/bolabaden/bolabaden-infra/security/code-scanning/37](https://github.com/bolabaden/bolabaden-infra/security/code-scanning/37)

The correct fix is to remove the ability to disable TLS certificate validation in this function, so all HTTPS requests use normal certificate verification (default secure behavior). In practice, that means removing the `https` agent override with `rejectUnauthorized: false`, and not conditionally injecting insecure axios options.

In `src/firecrawl/apps/api/src/lib/robots-txt.ts`, update `fetchRobotsTxt` to stop constructing `extraArgs` and stop spreading it into the axios config. Keep the existing function signature to avoid breaking callers, but ignore `skipTlsVerification` in this function implementation so behavior remains compatible except for the insecure bypass. Also remove the now-unused `https` import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
