### PR TITLE
Potential fix for code scanning alert no. 14: Server-side request forgery

### DIFF
--- a/src/firecrawl/apps/api/src/lib/robots-txt.ts
+++ b/src/firecrawl/apps/api/src/lib/robots-txt.ts
@@ -4,6 +4,59 @@ import { axiosTimeout } from "./timeout";
 import https from "https";
 import { Logger } from "winston";
 
+function isIPv4Address(hostname: string): boolean {
+  return /^(?:\d{1,3}\.){3}\d{1,3}$/.test(hostname);
+}
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split(".").map((x) => Number(x));
+  if (parts.length !== 4 || parts.some((x) => !Number.isInteger(x) || x < 0 || x > 255)) {
+    return null;
+  }
+  return (((parts[0] << 24) >>> 0) + (parts[1] << 16) + (parts[2] << 8) + parts[3]) >>> 0;
+}
+
+function isPrivateOrLocalIPv4(hostname: string): boolean {
+  const ipInt = ipv4ToInt(hostname);
+  if (ipInt === null) return false;
+
+  const inRange = (start: string, end: string): boolean => {
+    const s = ipv4ToInt(start)!;
+    const e = ipv4ToInt(end)!;
+    return ipInt >= s && ipInt <= e;
+  };
+
+  return (
+    inRange("10.0.0.0", "10.255.255.255") ||
+    inRange("127.0.0.0", "127.255.255.255") ||
+    inRange("169.254.0.0", "169.254.255.255") ||
+    inRange("172.16.0.0", "172.31.255.255") ||
+    inRange("192.168.0.0", "192.168.255.255") ||
+    inRange("0.0.0.0", "0.255.255.255")
+  );
+}
+
+function isDisallowedHostnameForServerSideFetch(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  if (!normalized) return true;
+
+  if (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized === "[::1]" ||
+    normalized === "0:0:0:0:0:0:0:1" ||
+    normalized === "[0:0:0:0:0:0:0:1]"
+  ) {
+    return true;
+  }
+
+  if (isIPv4Address(normalized) && isPrivateOrLocalIPv4(normalized)) {
+    return true;
+  }
+
+  return false;
+}
+
 export interface RobotsTxtChecker {
   robotsTxtUrl: string;
   robotsTxt: string;
@@ -16,6 +69,12 @@ export async function fetchRobotsTxt(
   abort?: AbortSignal,
 ): Promise<string> {
   const urlObj = new URL(url);
+  if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+    throw new Error("Unsupported URL protocol for robots.txt fetch");
+  }
+  if (isDisallowedHostnameForServerSideFetch(urlObj.hostname)) {
+    throw new Error("Blocked hostname for robots.txt fetch");
+  }
   const robotsTxtUrl = `${urlObj.protocol}//${urlObj.host}/robots.txt`;
 
   let extraArgs: any = {};


### PR DESCRIPTION
Potential fix for [https://github.com/bolabaden/bolabaden-infra/security/code-scanning/14](https://github.com/bolabaden/bolabaden-infra/security/code-scanning/14)

General fix: enforce SSRF-safe URL validation immediately before any outbound request, even if upstream already validates. Specifically, only allow `http:`/`https:` schemes and block localhost/private/link-local/loopback targets (including bracketed IPv6 localhost forms) for robots.txt fetches.

Best single fix (minimal behavior change): update `fetchRobotsTxt` in `src/firecrawl/apps/api/src/lib/robots-txt.ts` to validate the parsed URL hostname and protocol before building/sending `robotsTxtUrl`. Keep existing behavior otherwise (timeouts, TLS option, content-type filtering). If validation fails, throw an error so `checkRobotsTxt`’s existing `catch` path continues current functional behavior (it already treats fetch failures as allow=true and logs debug), thus avoiding breakage.

Changes needed:
- In `robots-txt.ts`, add helper functions:
  - `isIPv4Address`
  - `ipv4ToInt`
  - `isPrivateOrLocalIPv4`
  - `isDisallowedHostnameForServerSideFetch`
- In `fetchRobotsTxt`, after `new URL(url)`, enforce:
  - protocol is `http:` or `https:`
  - hostname is not disallowed
- No new package dependency required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
