### PR TITLE
docs: add orchestration knowledgebase

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ Key properties:
 | I want to… | Go to |
 |---|---|
 | Understand the overall roadmap | [Infrastructure Master Plan](INFRASTRUCTURE_MASTER_PLAN.md) |
+| Understand the orchestration direction | [Orchestration Overview](../orchestration/README.md) |
 | Deploy a new node or service | [Constellation Agent → Deployment Guide](../infra/docs/DEPLOYMENT_GUIDE.md) |
 | Configure secrets | [Docker Secrets Setup](../DOCKER_SECRETS_README.md) |
 | Troubleshoot a service | [Constellation Agent → Troubleshooting](../infra/docs/TROUBLESHOOTING.md) |
@@ -92,6 +93,7 @@ The short version: orchestrators like Kubernetes introduce a *control plane para
 | Document | Status | Last Updated |
 |---|---|---|
 | [Infrastructure Master Plan](INFRASTRUCTURE_MASTER_PLAN.md) | Active | 2026-03-03 |
+| [Orchestration Overview](../orchestration/README.md) | Active | 2026-06-04 |
 | [Constellation Agent Docs](../infra/docs/README.md) | Active | Ongoing |
 | [Orchestration Research 2026](orchestration_research_2026.md) | Research/Reference | 2026 |
 | [Stateful HA Plan](stateful_ha_plan.md) | Planning | Active |

--- a/docs/plans/20260604-orchestration-knowledgebase-foundation-plan.md
+++ b/docs/plans/20260604-orchestration-knowledgebase-foundation-plan.md
@@ -1,0 +1,315 @@
+# Orchestration Knowledgebase Foundation Plan
+
+## Summary
+
+Build a durable knowledgebase section that explains bolabaden's orchestration direction in one coherent narrative: the current Compose-first, no-heavy-orchestrator operating model; the near-term Constellation failover and coordination layer; and the longer-term CUE abstraction path that borrows selected ideas from Swarm/Mirantis and Kubernetes without adopting their control planes wholesale.
+
+The output of this plan is not a new scheduler. It is a docs-and-navigation foundation that makes the repo's orchestration story understandable, searchable, and internally consistent for operators and contributors.
+
+---
+
+## Problem Frame
+
+The repository already contains the ingredients of the orchestration story, but they are split across strategy docs, research notes, infra implementation docs, and experimental blueprint material:
+
+- `README.md` and `STRATEGY.md` clearly reject Kubernetes and Swarm as the primary operating model.
+- `docs/INFRASTRUCTURE_MASTER_PLAN.md` and `docs/brainstorms/20260604-failover-agent-exploration.md` define the near-term service-registry and failover direction.
+- `knowledgebase/UNIFIED_ORCHESTRATION_BLUEPRINT.md`, `knowledgebase/CUE_SPEC_EXTENSIONS.md`, and `knowledgebase/CUE_BOOTSTRAP_PROTOCOL.md` describe a more ambitious abstraction layer.
+- `infra/` already contains Constellation building blocks (`gossip`, `raft`, `failover`, `traefik`) but some docs still describe parts of the execution path as simulated.
+
+Without a curated knowledgebase path, readers have to infer the intended model themselves and may come away with contradictory conclusions: "manual Compose forever," "OpenSVC as the answer," or "we are secretly rebuilding Kubernetes." The plan should make the actual direction explicit and document the boundaries honestly.
+
+---
+
+## Scope Boundaries
+
+### In scope
+
+- Inventory and consolidate the repo's orchestration source set into a single knowledgebase path.
+- Explain how bolabaden maps and differentiates:
+  - Docker Compose
+  - Docker Swarm / Mirantis-style orchestration concepts
+  - Kubernetes-style orchestration concepts
+  - bolabaden's Constellation / CUE direction
+- Publish durable knowledgebase pages under `knowledgebase/` and wire them into `mkdocs.yml`.
+- Update landing/navigation surfaces so operators can find the new material from the docs home page.
+- Capture current-state vs near-term vs future-state maturity so the docs do not overclaim what is already implemented.
+
+### Out of scope
+
+- Implementing new failover, lease, or migration behavior in `infra/`.
+- Replacing the existing infrastructure model with Kubernetes, Swarm, or another orchestrator.
+- Exhaustively documenting every infra component; this plan is about the orchestration narrative and its primary supporting concepts.
+
+### Deferred to Follow-Up Work
+
+- Deep, service-by-service operator runbooks for every failover scenario.
+- External comparative research beyond the repo's existing materials, unless later docs work needs it.
+- Refactoring existing infra docs whose only problem is writing quality rather than orchestration ambiguity.
+
+---
+
+## Requirements
+
+- R1: The knowledgebase must state the canonical orchestration direction in language consistent with `STRATEGY.md`, `README.md`, and `docs/INFRASTRUCTURE_MASTER_PLAN.md`.
+- R2: The docs must clearly distinguish bolabaden's no-heavy-orchestrator stance from both manual-only Compose and full Kubernetes/Swarm control-plane designs.
+- R3: The docs must map familiar orchestration concepts (service identity, health, failover, placement, desired state, control plane, service registry) to bolabaden's current and planned equivalents.
+- R4: The docs must preserve current-state honesty by separating implemented behavior in `infra/` from blueprint/future-state material.
+- R5: The new material must live in `knowledgebase/` and be discoverable from `mkdocs.yml` navigation and the docs landing page.
+- R6: The docs must point readers to the most important supporting source documents and implementation surfaces.
+- R7: The docs changes must validate cleanly with the existing MkDocs and compose-based docs workflow.
+
+---
+
+## Key Technical Decisions
+
+- K1: Use a **three-layer narrative** throughout the knowledgebase:
+  - **Current state:** Compose-first, no central orchestrator, any-node ingress, Git-centered coordination.
+  - **Near-term control layer:** `services.yaml` concepts, failover agent, gossip/Raft coordination, lease-backed anti-split-brain behavior.
+  - **Future abstraction:** CUE / Constellation Unified Engine as the higher-level portable interface.
+  - **Why:** This matches the strongest repo evidence and resolves the current "manual Compose vs hidden orchestrator" ambiguity.
+
+- K2: Treat **`services.yaml` as the conceptual bridge**, not the Go `infra/config/service_registry.go` type.
+  - **Why:** The repo uses "service registry" for two different ideas; the knowledgebase must avoid conflating the internal provider registry with the distributed placement/routing registry described in strategy and failover docs.
+
+- K3: Publish the work as a **knowledgebase section**, not a plan-only artifact.
+  - **Why:** `docs/plans/` is excluded from the published site; the durable reader-facing outcome must live in `knowledgebase/` and then be linked from MkDocs navigation.
+
+- K4: Make **maturity and boundaries explicit** anywhere the docs mention Constellation automation.
+  - **Why:** Some implementation surfaces exist in `infra/`, but `infra/docs/CONSTELLATION_INTEGRATION.md` still describes migration execution as simulated. The docs should describe direction without overstating readiness.
+
+- K5: Anchor the comparison around **concept translation**, not feature parity.
+  - **Why:** The point is to help operators understand how bolabaden borrows ideas from Swarm/Mirantis and Kubernetes while keeping a different operational philosophy, not to claim one-to-one equivalence.
+
+---
+
+## Output Structure
+
+```text
+knowledgebase/
+└── orchestration/
+    ├── README.md                         # Landing page for the orchestration section
+    ├── orchestration-model.md            # Canonical current-state / near-term / future-state narrative
+    ├── concept-mapping.md                # Compose vs Swarm/Mirantis vs Kubernetes vs bolabaden mapping
+    └── constellation-control-layer.md    # Service registry, leases, failover agent, peer pickup, CUE bridge
+```
+
+The exact filenames may shift during implementation, but the final shape should include one section landing page plus a small set of focused concept pages rather than one oversized omnibus document.
+
+---
+
+## Implementation Units
+
+### U1. Establish the orchestration source set and information architecture
+
+**Goal:** Define the canonical set of source documents and the target information architecture for the orchestration knowledgebase section.
+
+**Requirements:** R1, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- `knowledgebase/`
+- `mkdocs.yml`
+- `docs/index.md`
+- `README.md`
+- `STRATEGY.md`
+- `docs/INFRASTRUCTURE_MASTER_PLAN.md`
+- `docs/brainstorms/20260604-failover-agent-exploration.md`
+- `knowledgebase/UNIFIED_ORCHESTRATION_BLUEPRINT.md`
+- `knowledgebase/CUE_SPEC_EXTENSIONS.md`
+- `knowledgebase/CUE_BOOTSTRAP_PROTOCOL.md`
+
+**Approach:**
+- Build a source inventory that separates authoritative direction docs from reference/alternative material.
+- Decide the section shape: landing page, model page, concept-mapping page, and Constellation control-layer page.
+- Reserve room for cross-links to supporting implementation and research docs instead of duplicating all of their content.
+
+**Patterns to follow:**
+- `docs/index.md` for quick-navigation and status-table patterns.
+- `docs/INFRASTRUCTURE_MASTER_PLAN.md` for canonical architecture terminology.
+- `knowledgebase/UNIFIED_ORCHESTRATION_BLUEPRINT.md` for future-state abstraction vocabulary.
+
+**Test scenarios:**
+- Happy path: The planned section structure covers the current operating model, near-term control layer, and future-state abstraction without leaving a major source document orphaned.
+- Edge case: Alternative/reference material such as OpenSVC and orchestration research remains linked as context, not elevated to the primary direction.
+- Verification case: A reviewer can point from each new page outline back to at least one authoritative source document.
+
+**Verification:**
+- The implementation has a clear source-of-truth list and a stable section outline before page authoring starts.
+
+### U2. Author the canonical orchestration model narrative
+
+**Goal:** Create the primary knowledgebase page that explains what bolabaden is doing, what it is not doing, and how the three-layer model fits together.
+
+**Requirements:** R1, R2, R4, R6
+
+**Dependencies:** U1
+
+**Files:**
+- `knowledgebase/orchestration/README.md`
+- `knowledgebase/orchestration/orchestration-model.md`
+
+**Approach:**
+- Write a concise landing page that routes readers to the right subtopics.
+- Write a canonical model page that:
+  - states the no-heavy-orchestrator boundary,
+  - explains the current Compose-first topology,
+  - introduces the Constellation failover/control-layer direction,
+  - positions CUE as the future abstraction layer rather than a claim of present-day parity.
+- Keep "implemented today" and "planned next" visibly separate.
+
+**Patterns to follow:**
+- `docs/index.md` for landing-page structure.
+- `README.md` and `STRATEGY.md` for the repo's current-state framing.
+
+**Test scenarios:**
+- Happy path: A new contributor can read the model page and correctly explain why the repo is neither "just manual Compose" nor "Kubernetes in disguise."
+- Edge case: A reader looking specifically for Swarm/Mirantis/Kubernetes comparisons can find the mapping page from the landing page without searching the whole site.
+- Error path: The page does not describe simulated or incomplete Constellation behavior as fully productionized.
+
+**Verification:**
+- The landing page and model page use consistent terminology and route readers to supporting docs without ambiguity.
+
+### U3. Document concept mapping across Compose, Swarm/Mirantis, Kubernetes, and bolabaden
+
+**Goal:** Publish the translation layer that helps operators understand equivalent concepts without implying one-to-one platform parity.
+
+**Requirements:** R2, R3, R6
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `knowledgebase/orchestration/concept-mapping.md`
+
+**Approach:**
+- Organize the page around a comparison matrix or grouped sections for:
+  - placement / scheduling
+  - service identity
+  - routing and ingress
+  - health and failover
+  - control plane / desired state
+  - secrets and storage constraints
+- For each concept, explain the bolabaden equivalent (or intentional non-equivalent) using current and planned constructs such as Traefik routing, `services.yaml`, gossip state, leases, and peer pickup.
+- Treat Mirantis in the Swarm-family context unless the repo has a distinct Mirantis-specific direction to document.
+
+**Patterns to follow:**
+- `docs/orchestration_research_2026.md` for comparative framing.
+- `knowledgebase/CUE_SPEC_EXTENSIONS.md` for the future abstraction surface.
+
+**Test scenarios:**
+- Happy path: A reader familiar with Kubernetes can identify the bolabaden equivalent or intentional omission for service registry, failover coordination, and desired-state behavior.
+- Edge case: Concepts with no exact equivalent are called out explicitly rather than forced into misleading parity language.
+- Error path: The comparison does not suggest that bolabaden currently has a full scheduler, controller-manager, or declarative reconciliation loop when it does not.
+
+**Verification:**
+- The comparison page reduces confusion instead of introducing new overloaded terms.
+
+### U4. Document the Constellation control layer and maturity boundaries
+
+**Goal:** Explain how `infra/` fits into the orchestration story today and where the failover/control-layer work is still emerging.
+
+**Requirements:** R3, R4, R6
+
+**Dependencies:** U2, U3
+
+**Files:**
+- `knowledgebase/orchestration/constellation-control-layer.md`
+- `infra/cmd/agent/main.go`
+- `infra/cluster/gossip/state.go`
+- `infra/cluster/raft/leases.go`
+- `infra/failover/migration.go`
+- `infra/docs/CONSTELLATION_INTEGRATION.md`
+
+**Approach:**
+- Document the role of gossip, leases, Traefik provider generation, and migration/failover logic in operator-facing terms.
+- Call out the difference between:
+  - implemented cluster primitives,
+  - planned service-registry and peer-pickup behavior,
+  - future CUE-driven abstraction.
+- Include the `services.yaml` bridge concept and explicitly warn against confusing it with the internal Go service registry type.
+
+**Patterns to follow:**
+- `infra/docs/ARCHITECTURE.md` and `infra/docs/COMPONENTS.md` for component descriptions.
+- `docs/brainstorms/20260604-failover-agent-exploration.md` for peer-pickup and split-brain problem framing.
+
+**Test scenarios:**
+- Happy path: A reader can trace how a service failure would be detected, coordinated, and routed around in the intended architecture.
+- Edge case: Statefulness, secret distribution, and split-brain constraints are presented as design boundaries where the docs should remain cautious.
+- Error path: The docs do not claim that all migration execution paths are already live if the linked infra docs still mark parts as simulated.
+
+**Verification:**
+- The Constellation page accurately reflects the code/docs maturity line and links to deeper implementation detail where needed.
+
+### U5. Wire the section into MkDocs navigation and validate the docs build
+
+**Goal:** Make the new orchestration material discoverable and keep the docs site healthy after the additions.
+
+**Requirements:** R5, R7
+
+**Dependencies:** U2, U3, U4
+
+**Files:**
+- `mkdocs.yml`
+- `docs/index.md`
+- `knowledgebase/orchestration/README.md`
+- `knowledgebase/orchestration/orchestration-model.md`
+- `knowledgebase/orchestration/concept-mapping.md`
+- `knowledgebase/orchestration/constellation-control-layer.md`
+
+**Approach:**
+- Add the new pages to the most appropriate section of `mkdocs.yml` with a coherent nav label set.
+- Update the docs landing page so the orchestration section is easy to find from the home page.
+- Validate links and ensure the new section does not break strict site generation.
+
+**Execution note:** Start with failing navigation/build validation if the new files are introduced incrementally; finish with a strict docs build once the nav is complete.
+
+**Patterns to follow:**
+- `mkdocs.yml` existing explicit-nav structure.
+- `docs/index.md` quick-navigation style.
+
+**Test scenarios:**
+- Happy path: The new orchestration pages appear in the rendered site nav and are reachable from the docs home page.
+- Edge case: Repo-relative links between the new pages and existing infra/docs content resolve correctly in the built site.
+- Error path: Strict build catches missing nav targets, broken internal links, or misplaced docs paths before the work is considered complete.
+
+**Verification:**
+- The docs site builds cleanly with the new pages included, and the new section is discoverable from both nav and the landing page.
+
+---
+
+## Risks & Dependencies
+
+### Risks
+
+- The repo currently carries multiple orchestration narratives (README, master plan, blueprint, OpenSVC research); poor synthesis could preserve confusion instead of reducing it.
+- The "service registry" term is overloaded and could mislead readers without careful distinction.
+- The docs may accidentally overstate implementation maturity if blueprint and code-level material are merged without clear boundaries.
+- MkDocs nav changes can fail quietly if page paths or relative links drift.
+
+### Dependencies
+
+- The authoritative direction docs listed in U1 remain the baseline sources.
+- `mkdocs.yml` continues to publish from `knowledgebase/`.
+- The docs validation path remains the existing strict MkDocs build and compose-backed docs workflow.
+
+---
+
+## Sources & Research
+
+- `STRATEGY.md`
+- `README.md`
+- `docs/INFRASTRUCTURE_MASTER_PLAN.md`
+- `plan-infrastructure-unification.md`
+- `docs/brainstorms/20260604-failover-agent-exploration.md`
+- `docs/orchestration_research_2026.md`
+- `knowledgebase/UNIFIED_ORCHESTRATION_BLUEPRINT.md`
+- `knowledgebase/CUE_SPEC_EXTENSIONS.md`
+- `knowledgebase/CUE_BOOTSTRAP_PROTOCOL.md`
+- `infra/cmd/agent/main.go`
+- `infra/cluster/gossip/state.go`
+- `infra/cluster/raft/leases.go`
+- `infra/failover/migration.go`
+- `infra/docs/CONSTELLATION_INTEGRATION.md`
+- `mkdocs.yml`
+- `docs/index.md`

--- a/knowledgebase/CUE_BOOTSTRAP_PROTOCOL.md
+++ b/knowledgebase/CUE_BOOTSTRAP_PROTOCOL.md
@@ -43,7 +43,7 @@ Once the mesh is alive, CUE connects to the cluster's Kine (SQLite) database.
    * Creates `/opt/cue/volumes` for local persistence.
    * Sets up `/run/secrets` as a `tmpfs` (RAM) mount.
 3. **System Plane Deployment**: Automatically pulls and starts core system pods (Traefik, Dozzle, Watchtower) if they are designated for this node.
-4. **Recursive Spec Application**: CUE executes the `cue up` cycle on the `docker-compose.yml` manifest, applying all `x-cue` extensions (see [knowledgebase/CUE_SPEC_EXTENSIONS.md](knowledgebase/CUE_SPEC_EXTENSIONS.md)) to the local containerd instance.
+4. **Recursive Spec Application**: CUE executes the `cue up` cycle on the `docker-compose.yml` manifest, applying all `x-cue` extensions (see [CUE Specification Extensions](CUE_SPEC_EXTENSIONS.md)) to the local containerd instance.
 
 ***
 

--- a/knowledgebase/SECURITY_STATUS.md
+++ b/knowledgebase/SECURITY_STATUS.md
@@ -1,0 +1,22 @@
+# Security Status
+
+This page is a lightweight index for the repository's current security-oriented documentation.
+
+## Current posture
+
+bolabaden is a multi-node infrastructure repo with several security-relevant surfaces:
+
+- public ingress through Traefik and Cloudflare
+- secret distribution through `${SECRETS_PATH}`-backed files and Compose secrets
+- internal node-to-node coordination over Tailscale / Headscale
+- service-specific security hardening documented in feature-area docs
+
+## Primary references
+
+- [KotorModSync Security Summary](docs/KOTORMODSYNC_SECURITY_SUMMARY.md)
+- [Docker Secrets Setup](DOCKER_SECRETS_README.md)
+- `SECURITY.md` in the GitHub metadata for repository disclosure and reporting policy
+
+## Important note
+
+This page is intentionally short. It exists so the published docs navigation has a stable security entry point while deeper security guidance continues to live with the subsystems it describes.

--- a/knowledgebase/UNIFIED_ORCHESTRATION_BLUEPRINT.md
+++ b/knowledgebase/UNIFIED_ORCHESTRATION_BLUEPRINT.md
@@ -66,7 +66,7 @@ Rather than writing a cluster manager from scratch, CUE leverages a hybrid archi
 
 * **The Database Layer (Kine-Backended)**: CUE replaces heavy, distributed `etcd` arrays with Rancher's `kine`, translating the complete Kubernetes API state into a lightweight SQL transaction stream (stored natively in SQLite or a shared PostgreSQL database).
 * **The Execution Engine (`containerd` & `podman` Core)**: Rather than running containers via a bloated Docker daemon, CUE interacts directly with the standard `containerd` API via OCI containers, or mimics daemonless execution namespaces using `podman`. This ensures extremely low idle CPU and memory consumption.
-* **The State Synchronization Layer**: Utilizing our proven Go-based orchestration primitives from [knowledgebase/infra/docs/ARCHITECTURE.md](knowledgebase/infra/docs/ARCHITECTURE.md), CUE synchronizes service health and local node capabilities across the server cluster using Gossip protocols (HashiCorp Memberlist) and Raft consensus for atomic updates.
+* **The State Synchronization Layer**: Utilizing our proven Go-based orchestration primitives from [Constellation Agent Architecture](infra/docs/ARCHITECTURE.md), CUE synchronizes service health and local node capabilities across the server cluster using Gossip protocols (HashiCorp Memberlist) and Raft consensus for atomic updates.
 
 ***
 
@@ -107,14 +107,14 @@ To achieve our goal of being "more unified than Swarm or K3s," CUE implements a 
 
 ### 🚀 Strategic "Clean" Manifests (`x-cue`)
 
-As documented in [knowledgebase/CUE_SPEC_EXTENSIONS.md](knowledgebase/CUE_SPEC_EXTENSIONS.md), CUE's true power lies in its **Recursive Capability**. We prioritize the work in existing `compose/` files and `docker-compose.yml` by treating them as the **Primary Declarative Manifest**.
+As documented in [CUE Specification Extensions](CUE_SPEC_EXTENSIONS.md), CUE's true power lies in its **Recursive Capability**. We prioritize the work in existing `compose/` files and `docker-compose.yml` by treating them as the **Primary Declarative Manifest**.
 
 Instead of manual K8s YAML or HCL jobs, CUE reads standard Compose files and extracts "Kube-Level" requirements from the `x-cue` extension namespace. This approach bridges the gap that frustrated previous Nomad/K8s attempts:
 
 1.  **Definitions remain human-readable.**
 2.  **No manual K8s/Nomad boilerplate is required.**
 3.  **The system remains portable.** (Standard Docker just ignores the `x-cue` keys).
-4.  **Implicit Hardware Intelligence.** Porting the logic from [infra/services.go](infra/services.go), CUE automatically adds GPU passthrough and Transcoding optimizations based on service identity.
+4.  **Implicit Hardware Intelligence.** Porting the logic from `infra/services.go`, CUE automatically adds GPU passthrough and transcoding optimizations based on service identity.
 
 ***
 
@@ -199,7 +199,7 @@ CUE's controller detects these labels and **atomically generates** the K8s Servi
 
 ## ⚡ Zero-ENV Single-Command Boostrapper
 
-To eliminate configuration drift, human error, and manual steps (detailed in [SECRETS\_QUICK\_START.txt](SECRETS_QUICK_START.txt)), CUE introduces a fully integrated, zero-configuration bootstrap command.
+To eliminate configuration drift, human error, and manual steps (detailed in [Docker Secrets Setup](DOCKER_SECRETS_README.md)), CUE introduces a fully integrated, zero-configuration bootstrap command.
 
 ```bash
 # To bootstrap a brand-new multi-node cluster, run a single script:
@@ -250,7 +250,7 @@ When adding a secondary node to the cluster, the operator simply executes:
 curl -fsSL https://get.bolabaden.org | sh -s join --token <TOKEN_FROM_MASTER> --master-ip <MASTER_TAILSCALE_IP>
 ```
 
-Server B automatically installs CUE, connects to the existing Private VPN mesh over Tailscale, downloads system configuration secrets securely, and joins the cluster database. Within seconds, it begins running applications scheduled across the cluster, completely eliminating the manual VPS setups highlighted in [cloud-init-bootstrap.sh](cloud-init-bootstrap.sh).
+Server B automatically installs CUE, connects to the existing private VPN mesh over Tailscale, downloads system configuration secrets securely, and joins the cluster database. Within seconds, it begins running applications scheduled across the cluster, completely eliminating the manual VPS setups highlighted in `cloud-init-bootstrap.sh`.
 
 ***
 
@@ -262,8 +262,8 @@ Every nodes running CUE automatically launches our core "system-plane" services,
 
 * **Role**: Standard border router, L7 load balancer, and TLS termination manager.
 * **Embedded Config**: Configured out-of-the-box with a dynamic Let's Encrypt Acme client integrated with the cluster's Cloudflare verification layer.
-* **Automatic Wildcards**: Routes external queries for `*.bolabaden.org` to local container endpoints, querying the cluster's internal state directory dynamically (replaces static files via Traefik.go's implementation in [knowledgebase/infra/docs/CONFIGURATION.md](knowledgebase/infra/docs/CONFIGURATION.md)).
-* **L4 Routing**: Exposes dynamic HAProxy tunnels (modeled on [compose/docker-compose.l4-ingress.yml](compose/docker-compose.l4-ingress.yml)) using Traefik's native TCP routers for database services.
+* **Automatic Wildcards**: Routes external queries for `*.bolabaden.org` to local container endpoints, querying the cluster's internal state directory dynamically (replaces static files via Traefik.go's implementation in [Constellation Agent Configuration](infra/docs/CONFIGURATION.md)).
+* **L4 Routing**: Exposes dynamic HAProxy tunnels (modeled on `compose/docker-compose.l4-ingress.yml`) using Traefik's native TCP routers for database services.
 
 ### 2. Watchtower (Zero-Downtime Updater)
 
@@ -317,7 +317,7 @@ Bringing CUE to fruition is structured into four distinct development phases, pr
 
 ### Phase 4: Production Verification & Scaling (Month 9+)
 
-* Move all 57+ docker-compose stacks ([docker-compose.yml](docker-compose.yml)) to run natively on CUE.
+* Move all 57+ docker-compose stacks (`docker-compose.yml`) to run natively on CUE.
 * Test geographical node outages, connection packet drops, and automatic failover times.
 * Release stable 1.0.0 distribution templates for the community.
 

--- a/knowledgebase/orchestration/README.md
+++ b/knowledgebase/orchestration/README.md
@@ -1,0 +1,36 @@
+# Orchestration Overview
+
+This section explains how bolabaden approaches orchestration without adopting a heavyweight control plane.
+
+The short version:
+
+- **Today:** the platform is still **Compose-first** and **Git-centered**.
+- **Next:** Constellation adds a lightweight coordination layer for health, routing, leases, and failover.
+- **Later:** CUE becomes the higher-level abstraction that keeps Compose as the authoring surface while adding stronger cluster behavior where it matters.
+
+## Read this section in order
+
+1. [Orchestration Model](orchestration-model.md) - the canonical current-state, near-term, and future-state narrative
+2. [Concept Mapping](concept-mapping.md) - how bolabaden concepts relate to Compose, Swarm/Mirantis, and Kubernetes
+3. [Constellation Control Layer](constellation-control-layer.md) - the concrete control primitives already in `infra/` and the boundaries they still have
+
+## What this section is for
+
+Use this section when you need to answer any of these questions:
+
+- "Are we trying to become Kubernetes?"
+- "How is this different from just running Docker Compose on a few VPSs?"
+- "Where do service registry, leases, failover, and peer pickup fit?"
+- "What is CUE supposed to unify?"
+
+## Primary source documents
+
+- `STRATEGY.md`
+- [Infrastructure Master Plan](../docs/INFRASTRUCTURE_MASTER_PLAN.md)
+- [Multi-Node Philosophy](../plan-infrastructure-unification.md)
+- [Failover Agent Brainstorm](../docs/brainstorms/20260604-failover-agent-exploration.md)
+- [Constellation Unified Engine Blueprint](../UNIFIED_ORCHESTRATION_BLUEPRINT.md)
+
+## Boundary
+
+This section documents the intended model. It does **not** claim that every future CUE capability already exists in the current Go implementation.

--- a/knowledgebase/orchestration/concept-mapping.md
+++ b/knowledgebase/orchestration/concept-mapping.md
@@ -1,0 +1,100 @@
+# Concept Mapping
+
+This page translates familiar orchestration concepts into bolabaden's current and planned equivalents.
+
+The goal is orientation, not one-to-one feature parity.
+
+## Comparison at a glance
+
+| Concept | Compose | Swarm / Mirantis | Kubernetes | bolabaden today | bolabaden direction |
+|---|---|---|---|---|---|
+| **Authoring surface** | `docker-compose.yml` | Compose stack / service specs | YAML manifests / Helm / controllers | Compose files in repo | Compose plus `x-cue` extensions |
+| **Source of truth** | local files per host | manager state | API server / etcd | Git repo + per-node runtime state | Git + lightweight distributed coordination |
+| **Service identity** | service name on one host | replicated service | Service / Deployment / StatefulSet | service labels + routing patterns | service registry plus cluster-visible service identity |
+| **Placement** | manual host choice | scheduler decides nodes | scheduler decides nodes | manual node assignment | preferred-node and peer-pickup logic rather than a general scheduler |
+| **Health routing** | container health on one host | service health across swarm | probes + services + ingress | Traefik + local checks + DNS-level failover | gossip-fed health, richer cluster signals, and more durable routing decisions |
+| **Failover** | manual or external tooling | manager reschedules tasks | controllers reschedule pods | DNS failover + manual operator-driven service recovery | lease-backed service pickup and migration coordination |
+| **Strong coordination** | none | manager quorum | control plane consensus | no cluster-wide coordination guarantee today | Raft-backed lease decisions where anti-split-brain coordination is needed |
+| **Desired state** | mostly imperative host state | service replicas/state | declarative reconciliation loop | current state plus automation helpers | selective declarative behavior, not full general reconciliation |
+| **Secrets** | files / env / secrets mounts | swarm secrets | Secret objects | secret files and env management | stronger sync / derivation and CUE-oriented secret handling |
+| **Ingress** | host ports / reverse proxy | routing mesh / LB | ingress / gateway API | Traefik with any-node ingress | durable cluster-aware routing generation |
+
+## What bolabaden keeps from Compose
+
+bolabaden keeps Compose because it is still the clearest operator-facing declaration of:
+
+- what services exist
+- how they are wired
+- what images, labels, volumes, and healthchecks they need
+
+That is why the long-range abstraction material keeps returning to **Compose compatibility** instead of requiring a hard pivot to handwritten Kubernetes manifests.
+
+## What bolabaden borrows from Swarm / Mirantis
+
+The useful ideas are mostly around **service-level thinking**:
+
+- service identity above a single container
+- health-aware traffic shifting
+- multi-node failover expectations
+- a more operator-friendly model than raw host-by-host Compose commands
+
+The repo does **not** currently position Swarm or Mirantis as the platform to adopt. They matter here as part of the comparison language and as proof that Compose-adjacent orchestration concepts are legitimate.
+
+## What bolabaden borrows from Kubernetes
+
+The repo borrows selected **control-plane concepts**, not the whole platform:
+
+- stronger service identity
+- richer health and readiness semantics
+- policy / extension surfaces
+- safer coordination for cluster-wide actions
+- a path toward declarative intent where it reduces operator toil
+
+The repo does **not** currently claim:
+
+- a full Kubernetes API in production
+- a generic scheduler that can place arbitrary workloads anywhere
+- complete parity with Deployments, StatefulSets, or controller-manager behavior
+
+## Intentional non-equivalents
+
+Some concepts should stay explicitly non-equivalent:
+
+### Full scheduler
+
+bolabaden is not trying to become a generic bin-packing scheduler. The direction is closer to:
+
+- preferred node placement
+- explicit service identity
+- peer pickup when a node fails
+- enough coordination to avoid split-brain and dead routes
+
+### Centralized control plane
+
+The repo's strategy rejects a heavyweight always-on control plane as the foundation. That means the platform should be described as **agent-assisted coordination**, not as a strict analogue of the Kubernetes API server plus controller-manager stack.
+
+### General declarative reconciliation
+
+The future direction does introduce more declarative behavior, but the current and near-term posture is still selective. The docs should not imply a fully general desired-state loop for every resource the way Kubernetes does.
+
+## The important bridge term: service registry
+
+In the orchestration docs, `services.yaml` is the architectural bridge between today's Compose files and tomorrow's stronger service identity layer.
+
+It means:
+
+- where a service is expected to run
+- where a proxy should route
+- which node is preferred or currently active
+
+It does **not** mean the internal Go service-provider registry in `infra/config/service_registry.go`.
+
+## How to read future CUE docs
+
+When you see CUE material describing things like `x-cue`, bootstrap phases, or cluster-wide service intelligence, interpret them as:
+
+- a portable abstraction direction
+- a vocabulary for future operator experience
+- a bridge for unifying the current platform's best ideas
+
+Do **not** interpret them as proof that the current repo already ships a full orchestrator.

--- a/knowledgebase/orchestration/constellation-control-layer.md
+++ b/knowledgebase/orchestration/constellation-control-layer.md
@@ -1,0 +1,139 @@
+# Constellation Control Layer
+
+Constellation is the control layer that explains how bolabaden can stay Compose-first while still adding real multi-node coordination.
+
+## What this layer does
+
+In practical terms, the control layer is responsible for:
+
+- discovering peers
+- sharing health information
+- coordinating cluster-wide actions that cannot tolerate split-brain
+- generating durable routing state from cluster knowledge instead of one host's local Docker view
+- supporting service failover and peer pickup as the repo hardens that path
+
+## The main primitives
+
+### Gossip state
+
+Constellation uses gossip to spread cluster knowledge:
+
+- node metadata
+- service health
+- WARP health
+
+This gives every node a local view of the cluster without introducing a central registry that all reads must go through.
+
+Primary references:
+
+- `infra/cluster/gossip/state.go`
+- `infra/docs/ARCHITECTURE.md`
+- `infra/docs/COMPONENTS.md`
+
+### Raft-backed leases
+
+Some actions need stronger guarantees than gossip can provide. The repo already uses Raft-backed leases for operations such as:
+
+- load-balancer leadership
+- DNS-writer ownership
+
+The newer failover direction extends that pattern toward **per-service fencing** so two nodes do not both believe they own the same service after a failure or recovery event.
+
+Primary references:
+
+- `infra/cluster/raft/leases.go`
+- `infra/cluster/raft/fsm.go`
+- `infra/cluster/raft/consensus.go`
+
+### Traefik provider generation
+
+A major part of the control-layer story is that routing should not disappear just because one host's Docker state changed.
+
+Instead of trusting only the local Docker socket:
+
+- Constellation exposes Traefik provider data from cluster state
+- routes can continue to represent healthy remote backends
+- failover stays possible even when the local container that previously owned a route has died
+
+This is one of the clearest ways bolabaden moves beyond raw host-local Compose behavior without adopting Kubernetes ingress machinery.
+
+Primary reference:
+
+- `infra/traefik/http_provider.go`
+
+### Migration and peer pickup
+
+The failover direction described in the repo is not "delete a dead route and hope DNS helps." It is moving toward:
+
+- detecting unhealthy or dead service owners
+- coordinating which peer is allowed to pick up the service
+- using leases/fencing to prevent split-brain
+- making routing and service ownership converge on the surviving node
+
+Primary references:
+
+- `docs/brainstorms/20260604-failover-agent-exploration.md`
+- `infra/failover/migration.go`
+
+## The `services.yaml` bridge
+
+Architecturally, the repo keeps pointing to a simple distributed `services.yaml` registry as the bridge concept between:
+
+- service definitions in Compose
+- routing state in Traefik
+- cluster-visible placement and failover intent
+
+That registry matters because it lets the system reason about **service identity** even when local containers die.
+
+Important boundary:
+
+- the architectural `services.yaml` registry is **not** the same thing as `infra/config/service_registry.go`
+- the former is a distributed placement/routing concept
+- the latter is an internal Go registry for service providers
+
+## Current maturity boundaries
+
+The control-layer story is real, but the maturity line matters:
+
+- Constellation already has concrete gossip, lease, routing, and health-monitoring primitives.
+- The failover/migration path exists in code and docs, but some execution paths are still documented as simulated or partial.
+- The repo is still evolving the exact service-registry, peer-pickup, secret-distribution, and stateful-failover story.
+
+That means the docs should talk about three categories explicitly:
+
+1. **Implemented primitives** - gossip, selected leases, health state, provider generation
+2. **In-progress failover behavior** - migration framework, fencing-token direction, peer pickup
+3. **Future abstraction** - CUE as the portable higher-level surface
+
+## Open constraints the docs should keep visible
+
+The control layer does not erase hard distributed-systems problems. The repo already names several:
+
+- **Split brain** - two nodes must not both believe they own a service
+- **Secrets distribution** - peer pickup requires the right secret material on the surviving node
+- **Stateful workloads** - storage and replication still matter; moving a container is not the same as moving healthy state
+
+These are not footnotes. They are part of the reason the repo wants a careful, incremental coordination layer instead of pretending failover is solved by restarting containers elsewhere.
+
+## Practical mental model
+
+If the platform's current stack is:
+
+- Compose for service definition
+- Traefik for ingress
+- Cloudflare for node-level DNS failover
+
+then Constellation is the layer that makes those pieces behave more like a coherent multi-node system:
+
+- gossip for awareness
+- Raft for the decisions that must be singular
+- provider generation for durable routing
+- migration and peer-pickup logic for service continuity
+
+## Related reading
+
+- [Orchestration Model](orchestration-model.md)
+- [Concept Mapping](concept-mapping.md)
+- [Constellation Agent Architecture](../infra/docs/ARCHITECTURE.md)
+- [Infrastructure Master Plan](../docs/INFRASTRUCTURE_MASTER_PLAN.md)
+- [Failover Agent Brainstorm](../docs/brainstorms/20260604-failover-agent-exploration.md)

--- a/knowledgebase/orchestration/orchestration-model.md
+++ b/knowledgebase/orchestration/orchestration-model.md
@@ -1,0 +1,104 @@
+# Orchestration Model
+
+bolabaden is building an orchestration story in layers instead of jumping straight from Docker Compose to a full Kubernetes-style control plane.
+
+## The canonical position
+
+bolabaden is **not** trying to:
+
+- stay forever at "manual docker compose on a few hosts"
+- adopt Docker Swarm or Mirantis as the platform's long-term control plane
+- migrate the stack wholesale to Kubernetes
+
+bolabaden **is** trying to:
+
+- keep **Compose** as the familiar service authoring surface
+- keep **Git** as the operational source of truth
+- add a lightweight **control layer** for service identity, health, failover, and routing
+- grow toward a more intuitive abstraction only where the current model breaks down under multi-node pressure
+
+## Layer 1: Current operating model
+
+Today the repo is fundamentally a **multi-node Docker Compose system** with any-node ingress:
+
+- Cloudflare provides multi-record DNS failover
+- Traefik handles L7 routing and health-aware proxying
+- each node can serve local traffic or proxy to a peer
+- operators still reason in Compose files, repo commits, and node-local services
+
+This is the model described most directly in:
+
+- [README](../README.md)
+- `STRATEGY.md`
+- [Infrastructure Master Plan](../docs/INFRASTRUCTURE_MASTER_PLAN.md)
+
+The important constraint is that bolabaden does **not** want a heavyweight centralized scheduler just to get resilient routing and failover.
+
+## Layer 2: Near-term control layer
+
+The next layer is a **Constellation-backed coordination system** that closes the gap between "just Compose" and "real multi-node behavior."
+
+This layer introduces or sharpens concepts such as:
+
+- a cluster-visible **service registry** (`services.yaml` in the architectural docs)
+- **gossip state** for node and service health
+- **Raft-backed leases** for actions that cannot tolerate split-brain
+- **persistent routing** that survives local container failure
+- **peer pickup** when a node can no longer host a service
+
+This is the part of the strategy that solves the manual synchronization bottleneck without introducing Kubernetes as the answer to every problem.
+
+Primary references:
+
+- [Failover Agent Brainstorm](../docs/brainstorms/20260604-failover-agent-exploration.md)
+- [Constellation Agent Architecture](../infra/docs/ARCHITECTURE.md)
+- [Constellation Integration Plan](../infra/docs/CONSTELLATION_INTEGRATION.md)
+
+## Layer 3: Future abstraction layer (CUE)
+
+The long-range direction is **CUE**: a higher-level interface that keeps the Compose authoring experience but adds stronger orchestration semantics.
+
+The repo's blueprint describes this as:
+
+- a **Compose soul** - keep the operator-facing authoring surface readable and portable
+- a **headless Kubernetes** posture - adopt stronger cluster ideas only where they reduce real operator pain
+- a **translation layer** - support richer scheduling, failover, and policy behavior without forcing the whole repo into handwritten Kubernetes YAML
+
+That future state matters because it explains why the docs talk about:
+
+- `x-cue` spec extensions
+- cluster-aware bootstrap
+- service identity and health beyond one host
+- concept mapping between Compose and Kubernetes-like behavior
+
+But it is still a **future abstraction target**, not a statement that the current repo already exposes a full Kube-compatible control plane.
+
+## Why not just stop at Compose?
+
+The repo's architecture docs repeatedly surface the same failure modes:
+
+- manual secret and env drift across nodes
+- failover logic that disappears when local containers stop
+- DNS and routing conflicts during node loss
+- operational overhead from managing several "almost coordinated" hosts by hand
+
+That is why the platform needs more than plain Compose, but less than a heavyweight orchestrator.
+
+## Why not just switch to Swarm or Kubernetes?
+
+The repo's position is not "those tools are useless." It is:
+
+- **Swarm/Mirantis** brings some useful service and failover concepts, but does not define the future direction here
+- **Kubernetes** solves classes of clustering problems, but brings a control-plane and operational cost the repo is explicitly trying to avoid
+- bolabaden wants a **selective unification** of the concepts that matter, using tooling and abstractions that fit the homelab / small-infra operator problem better
+
+## Operator mental model
+
+If you need a single sentence mental model:
+
+> bolabaden is building a Compose-first, Git-centered, agent-assisted coordination layer that borrows selected ideas from Swarm and Kubernetes without adopting either platform as the primary operating model.
+
+## Where to go next
+
+- Read [Concept Mapping](concept-mapping.md) if you want platform-to-platform translation.
+- Read [Constellation Control Layer](constellation-control-layer.md) if you want the concrete primitives and maturity boundaries.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,10 @@ nav:
     - Security Status: SECURITY_STATUS.md
 
   - Architecture:
+    - Orchestration Overview: orchestration/README.md
+    - Orchestration Model: orchestration/orchestration-model.md
+    - Orchestration Concept Mapping: orchestration/concept-mapping.md
+    - Constellation Control Layer: orchestration/constellation-control-layer.md
     - Infrastructure Master Plan: docs/INFRASTRUCTURE_MASTER_PLAN.md
     - Multi-Node Philosophy: plan-infrastructure-unification.md
     - Orchestration Research 2026: docs/orchestration_research_2026.md


### PR DESCRIPTION
## Summary
This publishes a single orchestration knowledgebase path for bolabaden instead of leaving the story split across strategy notes, brainstorms, and future-state design docs. Readers can now follow the current Compose-first posture, the near-term Constellation control layer, and the longer-term CUE abstraction without mistaking roadmap concepts for shipped behavior.

## What changed
- added a new orchestration section with a landing page, canonical model, concept mapping, and a dedicated Constellation control-layer explainer
- linked the section from the docs homepage and MkDocs navigation so the orchestration story is discoverable from the published site
- fixed stale knowledgebase links and added the missing security-status page so the strict MkDocs build stays green

## Validation
- `docker run --rm -v "$PWD:/docs" -w /docs squidfunk/mkdocs-material:latest build -f mkdocs.yml --strict`
- attempted a browser smoke pass against a locally served static build with `agent-browser`, but the local `agent-browser` daemon stayed unresponsive on this host after Chromium setup

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GitHub_Copilot_CLI_GPT-5.4](https://img.shields.io/badge/GitHub_Copilot_CLI-GPT--5.4-000000)
